### PR TITLE
fix: canvas read-only mode, auto-save race condition, snapshot persistence & auto-fit

### DIFF
--- a/app/interview/[id]/page.tsx
+++ b/app/interview/[id]/page.tsx
@@ -57,6 +57,7 @@ export default function InterviewCanvasPage({ params }: PageProps) {
     const statusResetRef = useRef<NodeJS.Timeout | null>(null);
     const isMountedRef = useRef(true);
     const canvasStateRef = useRef<CanvasStateRef | null>(null);
+    const saveAbortControllerRef = useRef<AbortController | null>(null);
 
     // Interview timer
     const timer = useInterviewTimer({
@@ -100,6 +101,10 @@ export default function InterviewCanvasPage({ params }: PageProps) {
     const performSave = useCallback(async (nodes: CanvasNode[], connections: Connection[]) => {
         if (!isMountedRef.current || session?.status !== 'in_progress') return;
 
+        // Create a new AbortController for this save so it can be cancelled on submit
+        const controller = new AbortController();
+        saveAbortControllerRef.current = controller;
+
         isSavingRef.current = true;
         setSaveStatus('saving');
 
@@ -107,6 +112,7 @@ export default function InterviewCanvasPage({ params }: PageProps) {
             const response = await authFetch(`/api/interview/${id}`, {
                 method: 'PUT',
                 body: JSON.stringify({ action: 'save', nodes, connections }),
+                signal: controller.signal,
             });
 
             if (!isMountedRef.current) return;
@@ -123,13 +129,15 @@ export default function InterviewCanvasPage({ params }: PageProps) {
                 }, 2000);
             }
         } catch (err) {
+            // Silently ignore aborted saves (expected when user submits)
+            if (err instanceof DOMException && err.name === 'AbortError') return;
             console.error('Error auto-saving:', err);
             if (isMountedRef.current) setSaveStatus('error');
         } finally {
             isSavingRef.current = false;
 
-            // Process pending save
-            if (pendingSaveRef.current && isMountedRef.current) {
+            // Process pending save (only if this save wasn't aborted)
+            if (!controller.signal.aborted && pendingSaveRef.current && isMountedRef.current) {
                 const pending = pendingSaveRef.current;
                 pendingSaveRef.current = null;
                 setTimeout(() => {
@@ -167,7 +175,8 @@ export default function InterviewCanvasPage({ params }: PageProps) {
     const handleSubmit = useCallback(async () => {
         if (!session || session.status !== 'in_progress' || isSubmitting) return;
 
-        // Cancel any pending auto-save to prevent 409 errors after status changes
+        // Cancel any pending or in-flight auto-save to prevent 409 errors after status changes
+        saveAbortControllerRef.current?.abort();
         if (saveTimeoutRef.current) {
             clearTimeout(saveTimeoutRef.current);
             saveTimeoutRef.current = null;
@@ -287,7 +296,7 @@ export default function InterviewCanvasPage({ params }: PageProps) {
     const isReadOnly = session.status !== 'in_progress';
 
     return (
-        <div className="flex flex-col h-screen overflow-hidden bg-background-dark text-white font-display">
+        <div className="relative flex flex-col h-screen overflow-hidden bg-background-dark text-white font-display">
             <InterviewHeader
                 difficulty={session.difficulty}
                 saveStatus={saveStatus}

--- a/app/interview/[id]/result/page.tsx
+++ b/app/interview/[id]/result/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { useRequireAuth } from '@/src/hooks/useRequireAuth';
 import { authFetch } from '@/src/lib/firebase/authClient';
 import { IInterviewQuestion, IEvaluation } from '@/src/lib/db/models/InterviewSession';
-import { DesignCanvas } from '@/components/canvas/DesignCanvas';
+import { DesignCanvas, CanvasNode, Connection } from '@/components/canvas/DesignCanvas';
 
 interface InterviewSessionData {
     id: string;
@@ -15,8 +15,8 @@ interface InterviewSessionData {
     status: string;
     evaluation: IEvaluation;
     canvasSnapshot: {
-        nodes: any[];
-        connections: any[];
+        nodes: CanvasNode[];
+        connections: Connection[];
     };
     startedAt: string;
     timeLimit: number;
@@ -360,8 +360,8 @@ export default function InterviewResultPage({ params }: PageProps) {
                     </div>
                     <div className="flex h-[600px] bg-sidebar-bg-dark border border-border-dark rounded-3xl overflow-hidden relative shadow-2xl shadow-black/50">
                         <DesignCanvas
-                            initialNodes={session.canvasSnapshot.nodes}
-                            initialConnections={session.canvasSnapshot.connections}
+                            initialNodes={session.canvasSnapshot?.nodes || []}
+                            initialConnections={session.canvasSnapshot?.connections || []}
                             readOnly={true}
                         />
                         <div className="absolute bottom-6 left-6 bg-background-dark/80 backdrop-blur-md border border-white/5 px-4 py-2 rounded-xl pointer-events-none">

--- a/components/canvas/DesignCanvas.tsx
+++ b/components/canvas/DesignCanvas.tsx
@@ -44,6 +44,7 @@ type HistoryState = {
 
 type HistoryAction =
   | { type: 'SET'; payload: CanvasState }
+  | { type: 'RESET'; payload: CanvasState }
   | { type: 'UNDO' }
   | { type: 'REDO' };
 
@@ -104,6 +105,15 @@ function historyReducer(state: HistoryState, action: HistoryAction): HistoryStat
         future: newFuture,
       };
     }
+    case 'RESET': {
+      // Replace present without pushing old state into undo history.
+      // Used for programmatic loads (e.g. async initial data) that aren't user edits.
+      return {
+        past: [],
+        present: action.payload,
+        future: [],
+      };
+    }
     default:
       return state;
   }
@@ -140,7 +150,7 @@ export function DesignCanvas({
     // Only sync once when real data arrives
     if (initialNodes.length > 0 || initialConnections.length > 0) {
       initialDataLoadedRef.current = true;
-      dispatch({ type: 'SET', payload: { nodes: initialNodes, connections: initialConnections } });
+      dispatch({ type: 'RESET', payload: { nodes: initialNodes, connections: initialConnections } });
     }
   }, [initialNodes, initialConnections]);
 
@@ -188,6 +198,10 @@ export function DesignCanvas({
     const containerW = container.clientWidth;
     const containerH = container.clientHeight;
 
+    // Container has no dimensions yet (layout hasn't painted). We intentionally
+    // don't set hasAutoFitRef.current = true so the effect retries on the next
+    // render once the container has non-zero dimensions.
+    // Alternative: use a ResizeObserver or requestAnimationFrame retry loop.
     if (containerW === 0 || containerH === 0) return;
 
     // Scale to fit, clamped between 50% and 100%


### PR DESCRIPTION
…tence & auto-fit

- Pass readOnly prop to DesignCanvas after submission to block all editing
- Hide Controls tooltip, delete buttons, and connection erase in read-only mode
- Cancel pending auto-saves on submit to prevent 409 conflicts
- Include canvas state in submit request to guarantee snapshot persistence
- Add stateRef prop to DesignCanvas for live state access by parent
- Add auto-fit zoom/pan in read-only mode to center all nodes in viewport
- Move submitted overlay from bottom to top to avoid toolbar collision
- Auto-redirect to results page after evaluation completes
- Fix result page canvas wrapper missing flex display (0-height bug)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only canvas mode with editing controls hidden and external state exposure for snapshots
  * Auto-save flow improved to manage and cancel pending saves during submission

* **Improvements**
  * Submission now includes the latest canvas state and redirects immediately to results
  * Results view layout and auto-fit behavior refined; submission confirmation repositioned for better visibility
  * Safer handling of missing snapshot data with sensible fallbacks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->