### PR TITLE
feat: add AI deep analysis panel & Playwright E2E testing pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,48 @@ jobs:
       - name: Typecheck
         run: npx tsc --noEmit
 
+  e2e-tests:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    needs: [lint-and-typecheck]
+    env:
+      # Minimal env vars needed for Next.js build (app won't auth in CI)
+      NEXT_PUBLIC_FIREBASE_API_KEY: "ci-placeholder"
+      NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: "ci-placeholder"
+      NEXT_PUBLIC_FIREBASE_PROJECT_ID: "ci-placeholder"
+      NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: "ci-placeholder"
+      NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: "ci-placeholder"
+      NEXT_PUBLIC_FIREBASE_APP_ID: "ci-placeholder"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload test report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+
   docker-build-test:
     name: Docker Build Test
     runs-on: ubuntu-latest
-    needs: [lint-and-typecheck]
+    needs: [lint-and-typecheck, e2e-tests]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ next-env.d.ts
 docs/
 eslint_output.txt
 .superdesign
+
+# Playwright
+node_modules/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "three": "^0.182.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -2041,6 +2042,22 @@
       "optional": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -5404,6 +5421,21 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -7917,6 +7949,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:e2e": "npx playwright test",
+    "test:e2e:ui": "npx playwright test --ui"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
@@ -25,6 +27,7 @@
     "three": "^0.182.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * SystemCraft E2E Test Configuration
+ * Runs against the local Next.js dev server on port 3000.
+ */
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+  timeout: 30_000,
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Auto-start the dev server before running tests */
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000, // Next.js cold-start can be slow
+  },
+});

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * SystemCraft — Auth Page Tests
+ * Login page: AuthCard with email/password form + Google/GitHub buttons.
+ * Inputs use label elements, not placeholders, for field identification.
+ */
+test.describe('Login Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+  });
+
+  test('renders login heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /Welcome Back/i })).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('renders email and password inputs', async ({ page }) => {
+    // Fields are identified by their labels, not placeholders
+    await expect(page.getByLabel(/email/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel(/password/i)).toBeVisible();
+  });
+
+  test('renders Google sign-in button', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /google/i })).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('renders GitHub sign-in button', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /github/i })).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('renders Sign In submit button', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /^Sign In$/i })).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('has link to create account (signup)', async ({ page }) => {
+    const signupLink = page.getByRole('link', { name: /create an account/i });
+    await expect(signupLink).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+test.describe('Signup Page', () => {
+  test('renders signup heading and name field', async ({ page }) => {
+    await page.goto('/signup');
+    await expect(page.getByRole('heading', { name: /Create an Account/i })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel(/full name/i)).toBeVisible();
+  });
+});

--- a/tests/landing.spec.ts
+++ b/tests/landing.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * SystemCraft — Landing Page Tests
+ * The landing page is public with Navbar + GalaxyHero + BentoGrid + Footer.
+ */
+test.describe('Landing Page', () => {
+  test('renders with correct title', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/SystemCraft/i);
+  });
+
+  test('navbar shows SystemCraft branding', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByText('SystemCraft').first()).toBeVisible();
+  });
+
+  test('navbar shows Get Started CTA when logged out', async ({ page }) => {
+    await page.goto('/');
+
+    // "Get Started" links to /signup
+    const cta = page.getByRole('link', { name: /Get Started/i });
+    await expect(cta).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('Get Started navigates to signup page', async ({ page }) => {
+    await page.goto('/');
+
+    const cta = page.getByRole('link', { name: /Get Started/i });
+    await cta.click();
+
+    await expect(page).toHaveURL(/signup/);
+  });
+
+  test('Sign In link navigates to login page', async ({ page }) => {
+    await page.goto('/');
+
+    // "Sign In" link only appears after auth loading resolves (hidden sm:flex)
+    const signIn = page.getByRole('link', { name: /Sign In/i });
+    await expect(signIn).toBeVisible({ timeout: 15_000 });
+    await signIn.click();
+
+    await expect(page).toHaveURL(/login/);
+  });
+});

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * SystemCraft — Navigation & Accessibility Tests
+ * Tests public pages (landing, login, signup) since dashboard requires auth.
+ */
+test.describe('Navigation', () => {
+  test('landing page navbar has Features, Pricing, Blog links', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('link', { name: /Features/i })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole('link', { name: /Pricing/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Blog/i })).toBeVisible();
+  });
+
+  test('login page has link back to signup', async ({ page }) => {
+    await page.goto('/login');
+
+    const createLink = page.getByRole('link', { name: /create an account/i });
+    await expect(createLink).toBeVisible({ timeout: 10_000 });
+    await createLink.click();
+
+    await expect(page).toHaveURL(/signup/);
+  });
+
+  test('signup page has link back to login', async ({ page }) => {
+    await page.goto('/signup');
+
+    const signInLink = page.getByRole('link', { name: /sign in/i });
+    await expect(signInLink).toBeVisible({ timeout: 10_000 });
+    await signInLink.click();
+
+    await expect(page).toHaveURL(/login/);
+  });
+});
+
+test.describe('Accessibility', () => {
+  test('landing page has no broken images', async ({ page }) => {
+    await page.goto('/');
+    // Wait for page to settle (Spline 3D, lazy images, etc.)
+    await page.waitForTimeout(3000);
+
+    const images = page.locator('img[src]');
+    const count = await images.count();
+
+    for (let i = 0; i < count; i++) {
+      const img = images.nth(i);
+      const src = await img.getAttribute('src');
+      // Skip non-standard sources (data URIs, blobs, inline SVGs, Next.js optimized)
+      if (!src || src.startsWith('data:') || src.startsWith('blob:') || src.includes('_next/image')) continue;
+      const naturalWidth = await img.evaluate((el: HTMLImageElement) => el.naturalWidth);
+      expect(naturalWidth, `Broken image: ${src}`).toBeGreaterThan(0);
+    }
+  });
+
+  test('login page buttons all have accessible text', async ({ page }) => {
+    await page.goto('/login');
+    await page.waitForTimeout(2000);
+
+    const buttons = page.getByRole('button');
+    const count = await buttons.count();
+
+    for (let i = 0; i < count; i++) {
+      const btn = buttons.nth(i);
+      const ariaLabel = await btn.getAttribute('aria-label');
+      const text = await btn.innerText().catch(() => '');
+      const hasName = (ariaLabel && ariaLabel.trim().length > 0) || (text && text.trim().length > 0);
+      expect(hasName, `Button ${i} missing accessible name`).toBeTruthy();
+    }
+  });
+});

--- a/tests/reference-architectures.spec.ts
+++ b/tests/reference-architectures.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * SystemCraft — Reference Architectures Tests
+ * These pages live under /dashboard/ which requires auth.
+ * Without auth, the page still renders (Next.js client-side routing)
+ * but the sidebar/auth context may redirect.
+ *
+ * We test the gallery and detail pages at the URL level,
+ * accepting that unauthenticated users may see a loading state or redirect.
+ */
+test.describe('Reference Architectures', () => {
+  test('gallery page loads without crashing', async ({ page }) => {
+    const response = await page.goto('/dashboard/reference-architectures');
+    // Should get a 200 (page exists, even if auth redirects client-side)
+    expect(response?.status()).toBeLessThan(500);
+  });
+
+  test('detail page for netflix-streaming loads without crashing', async ({ page }) => {
+    const response = await page.goto('/dashboard/reference-architectures/netflix-streaming');
+    expect(response?.status()).toBeLessThan(500);
+  });
+
+  test('detail page renders architecture title in top bar', async ({ page }) => {
+    await page.goto('/dashboard/reference-architectures/netflix-streaming');
+
+    // The top bar should contain the architecture name or "Gallery" back link
+    const galleryLink = page.getByText(/Gallery/i);
+    await expect(galleryLink.first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('detail page shows Read-Only badge', async ({ page }) => {
+    await page.goto('/dashboard/reference-architectures/netflix-streaming');
+    await expect(page.getByText(/Read-Only Reference/i)).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('detail page has Annotations and AI Analysis tabs', async ({ page }) => {
+    await page.goto('/dashboard/reference-architectures/netflix-streaming');
+
+    await expect(page.getByRole('button', { name: /Annotations/i })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('button', { name: /AI Analysis/i })).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('detail page has Deep Analysis button', async ({ page }) => {
+    await page.goto('/dashboard/reference-architectures/netflix-streaming');
+
+    await expect(page.getByRole('button', { name: /Deep Analysis/i })).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('invalid architecture ID shows Not Found', async ({ page }) => {
+    await page.goto('/dashboard/reference-architectures/nonexistent-arch-xyz');
+
+    await expect(page.getByText(/Not Found/i)).toBeVisible({ timeout: 15_000 });
+  });
+});


### PR DESCRIPTION
- Reference Architectures: add streaming AI analysis sidebar powered by Gemini 2.0 Flash via OpenRouter. Tabbed right panel switches between curated annotations and on-demand AI-generated deep analysis covering data flow, design decisions, scalability, trade-offs, failure modes, and interview tips.

- API hardening (analyze/route.ts): Array.isArray input validation, SSE carry-over buffer for partial frame handling, AbortSignal + 60s timeout on upstream fetch with client disconnect forwarding, and allowlist-based HTML sanitizer on rendered markdown output.

- E2E testing: configure Playwright with Chromium, add 4 test suites (landing, auth, reference-architectures, navigation/a11y) covering 24 test cases. Integrate into CI as a gating job before Docker build.

- CI pipeline: Lint → E2E Tests (Playwright) → Docker Build + Trivy → K8s Validate → Deploy