### PR TITLE
feat(helm): add Helm chart for multi-environment Kubernetes deployments

### DIFF
--- a/helm/systemcraft/Chart.yaml
+++ b/helm/systemcraft/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: systemcraft
+description: A Helm chart for the SystemCraft web application
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+maintainers:
+  - name: Shashank Chakraborty
+keywords:
+  - systemcraft
+  - nextjs
+  - web

--- a/helm/systemcraft/templates/NOTES.txt
+++ b/helm/systemcraft/templates/NOTES.txt
@@ -1,0 +1,15 @@
+🚀 SystemCraft has been deployed!
+
+Get the application URL:
+{{- if .Values.ingress.enabled }}
+  https://{{ .Values.ingress.host }}
+{{- else }}
+  kubectl port-forward svc/{{ include "systemcraft.fullname" . }}-service {{ .Values.service.port }}:{{ .Values.service.port }}
+  Then visit: http://localhost:{{ .Values.service.port }}
+{{- end }}
+
+Environment: {{ .Values.env.NODE_ENV }}
+Replicas:    {{ .Values.replicaCount }}
+Image:       {{ .Values.image.repository }}:{{ .Values.image.tag }}
+HPA:         {{ if .Values.hpa.enabled }}enabled ({{ .Values.hpa.minReplicas }}-{{ .Values.hpa.maxReplicas }}){{ else }}disabled{{ end }}
+Monitoring:  {{ if .Values.serviceMonitor.enabled }}enabled{{ else }}disabled{{ end }}

--- a/helm/systemcraft/templates/_helpers.tpl
+++ b/helm/systemcraft/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "systemcraft.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this.
+*/}}
+{{- define "systemcraft.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "systemcraft.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to every resource.
+*/}}
+{{- define "systemcraft.labels" -}}
+helm.sh/chart: {{ include "systemcraft.chart" . }}
+{{ include "systemcraft.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels — used in Deployment matchLabels and Service selector.
+*/}}
+{{- define "systemcraft.selectorLabels" -}}
+app: {{ include "systemcraft.name" . }}
+app.kubernetes.io/name: {{ include "systemcraft.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/systemcraft/templates/deployment.yaml
+++ b/helm/systemcraft/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "systemcraft.fullname" . }}
+  labels:
+    {{- include "systemcraft.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "systemcraft.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "systemcraft.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.service.targetPort }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 10 }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.probes.liveness.path }}
+            port: http
+          initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.probes.readiness.path }}
+            port: http
+          initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+        env:
+        - name: NODE_ENV
+          value: {{ .Values.env.NODE_ENV | quote }}
+        - name: MONGODB_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets.mongodb.secretName }}
+              key: {{ .Values.secrets.mongodb.key }}

--- a/helm/systemcraft/templates/hpa.yaml
+++ b/helm/systemcraft/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "systemcraft.fullname" . }}-hpa
+  labels:
+    {{- include "systemcraft.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "systemcraft.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.metrics.cpu.averageUtilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.metrics.memory.averageUtilization }}
+  {{- with .Values.hpa.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/systemcraft/templates/ingress.yaml
+++ b/helm/systemcraft/templates/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "systemcraft.fullname" . }}-ingress
+  labels:
+    {{- include "systemcraft.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host }}
+    secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "systemcraft.fullname" . }}-service
+            port:
+              number: {{ .Values.service.port }}
+{{- end }}

--- a/helm/systemcraft/templates/service.yaml
+++ b/helm/systemcraft/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "systemcraft.fullname" . }}-service
+  labels:
+    {{- include "systemcraft.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "systemcraft.selectorLabels" . | nindent 4 }}
+  ports:
+    - protocol: TCP
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      name: http

--- a/helm/systemcraft/templates/servicemonitor.yaml
+++ b/helm/systemcraft/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "systemcraft.fullname" . }}-monitor
+  labels:
+    {{- include "systemcraft.labels" . | nindent 4 }}
+    release: {{ .Values.serviceMonitor.releaseLabel }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "systemcraft.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/helm/systemcraft/values-dev.yaml
+++ b/helm/systemcraft/values-dev.yaml
@@ -1,0 +1,30 @@
+# ──────────────────────────────────────────────────────────────
+# Dev environment overrides
+# Usage: helm install systemcraft-dev ./helm/systemcraft -f helm/systemcraft/values-dev.yaml
+# ──────────────────────────────────────────────────────────────
+
+replicaCount: 1
+
+image:
+  tag: latest
+  pullPolicy: Always
+
+ingress:
+  enabled: false
+
+resources:
+  limits:
+    cpu: "250m"
+    memory: "256Mi"
+  requests:
+    cpu: "100m"
+    memory: "128Mi"
+
+env:
+  NODE_ENV: development
+
+hpa:
+  enabled: false
+
+serviceMonitor:
+  enabled: false

--- a/helm/systemcraft/values-prod.yaml
+++ b/helm/systemcraft/values-prod.yaml
@@ -1,0 +1,35 @@
+# ──────────────────────────────────────────────────────────────
+# Production environment overrides
+# Usage: helm install systemcraft-prod ./helm/systemcraft -f helm/systemcraft/values-prod.yaml
+# ──────────────────────────────────────────────────────────────
+
+replicaCount: 3
+
+image:
+  tag: latest  # Overridden by CI/CD with --set image.tag=$SHA
+  pullPolicy: IfNotPresent
+
+ingress:
+  enabled: true
+  host: system-craft-kohl.vercel.app
+  tls:
+    enabled: true
+    secretName: system-craft-tls
+
+resources:
+  limits:
+    cpu: "1000m"
+    memory: "1Gi"
+  requests:
+    cpu: "500m"
+    memory: "512Mi"
+
+hpa:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    cpu:
+      averageUtilization: 40
+    memory:
+      averageUtilization: 80

--- a/helm/systemcraft/values.yaml
+++ b/helm/systemcraft/values.yaml
@@ -1,0 +1,101 @@
+# ──────────────────────────────────────────────────────────────
+# Default values for SystemCraft Helm chart
+# Override per-environment with values-dev.yaml / values-prod.yaml
+# ──────────────────────────────────────────────────────────────
+
+replicaCount: 3
+
+image:
+  repository: ghcr.io/shashank0701-byte/system-craft/systemcraft-web
+  tag: latest
+  pullPolicy: IfNotPresent
+
+# ── Service ──────────────────────────────────────────────────
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+# ── Ingress ──────────────────────────────────────────────────
+ingress:
+  enabled: true
+  className: ""
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  host: system-craft-kohl.vercel.app
+  tls:
+    enabled: true
+    secretName: system-craft-tls
+
+# ── Container Resources ─────────────────────────────────────
+resources:
+  limits:
+    cpu: "500m"
+    memory: "512Mi"
+  requests:
+    cpu: "250m"
+    memory: "256Mi"
+
+# ── Health Probes ────────────────────────────────────────────
+probes:
+  liveness:
+    path: /api/health
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    path: /api/health
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+# ── Pod Security ─────────────────────────────────────────────
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+# ── Environment Variables ────────────────────────────────────
+env:
+  NODE_ENV: production
+
+# ── Secrets ──────────────────────────────────────────────────
+secrets:
+  mongodb:
+    secretName: mongodb-secret
+    key: uri
+
+# ── Horizontal Pod Autoscaler ────────────────────────────────
+hpa:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    cpu:
+      averageUtilization: 40
+    memory:
+      averageUtilization: 80
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Pods
+          value: 4
+          periodSeconds: 15
+    scaleDown:
+      stabilizationWindowSeconds: 300
+
+# ── ServiceMonitor (Prometheus) ──────────────────────────────
+serviceMonitor:
+  enabled: true
+  interval: 15s
+  path: /api/metrics
+  releaseLabel: prometheus


### PR DESCRIPTION
- Template all K8s manifests (deployment, service, ingress, HPA, ServiceMonitor)