### PR TITLE
fix(chore): add Helm chart for multi-environment Kubernetes deployments

### DIFF
--- a/helm/systemcraft/templates/NOTES.txt
+++ b/helm/systemcraft/templates/NOTES.txt
@@ -2,7 +2,7 @@
 
 Get the application URL:
 {{- if .Values.ingress.enabled }}
-  https://{{ .Values.ingress.host }}
+  {{- if .Values.ingress.tls.enabled }}https{{ else }}http{{ end }}://{{ .Values.ingress.host }}
 {{- else }}
   kubectl port-forward svc/{{ include "systemcraft.fullname" . }}-service {{ .Values.service.port }}:{{ .Values.service.port }}
   Then visit: http://localhost:{{ .Values.service.port }}

--- a/helm/systemcraft/values-prod.yaml
+++ b/helm/systemcraft/values-prod.yaml
@@ -6,7 +6,8 @@
 replicaCount: 3
 
 image:
-  tag: latest  # Overridden by CI/CD with --set image.tag=$SHA
+  # REQUIRED: CI/CD must override with --set image.tag=$SHA; never deploy unpinned
+  tag: "0.1.0"
   pullPolicy: IfNotPresent
 
 ingress:

--- a/helm/systemcraft/values.yaml
+++ b/helm/systemcraft/values.yaml
@@ -7,7 +7,8 @@ replicaCount: 3
 
 image:
   repository: ghcr.io/shashank0701-byte/system-craft/systemcraft-web
-  tag: latest
+  # Pinned default — CI/CD overrides with --set image.tag=$SHA per deploy
+  tag: "0.1.0"
   pullPolicy: IfNotPresent
 
 # ── Service ──────────────────────────────────────────────────


### PR DESCRIPTION
- Pin default image tag to 0.1.0 for reproducible deploys
- Derive NOTES.txt URL scheme from TLS setting