### PR TITLE
feat(security): add Bitnami Sealed Secrets for GitOps-safe secret management

### DIFF
--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -47,4 +47,155 @@ kubectl get hpa -n system-craft
 
 ---
 
-*This completes the full cycle: Dev -> Containerize -> Proxy -> Orchestrate -> Autoscale.*
+## Sealed Secrets (Bitnami)
+
+SystemCraft uses [Bitnami Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) to store encrypted secrets in Git. The sealed-secrets controller running in the cluster decrypts them into regular Kubernetes Secrets at deploy time.
+
+### Why Sealed Secrets?
+
+| Problem | Solution |
+|---|---|
+| `mongodb-secret` created manually via `kubectl create secret` — not in Git | Encrypted `SealedSecret` lives in the repo, version-controlled |
+| Cluster rebuild loses all secrets | Secrets are restored automatically from Git |
+| Breaks GitOps — ArgoCD can't manage what's not in Git | ArgoCD syncs sealed secrets like any other manifest |
+
+### Prerequisites
+
+1. **Install the Sealed Secrets controller** in your cluster:
+   ```bash
+   helm repo add sealed-secrets https://bitnami-labs.github.io/sealed-secrets
+   helm install sealed-secrets sealed-secrets/sealed-secrets \
+     --namespace kube-system \
+     --set-string fullnameOverride=sealed-secrets
+   ```
+
+2. **Install the `kubeseal` CLI** locally:
+   ```bash
+   # macOS
+   brew install kubeseal
+
+   # Linux
+   wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.27.3/kubeseal-0.27.3-linux-amd64.tar.gz
+   tar -xvzf kubeseal-*.tar.gz kubeseal
+   sudo install -m 755 kubeseal /usr/local/bin/kubeseal
+
+   # Windows (scoop)
+   scoop install kubeseal
+   ```
+
+### Creating a Sealed Secret
+
+**Step 1 — Generate a raw Secret (never committed):**
+```bash
+kubectl create secret generic systemcraft-secrets \
+  --namespace default \
+  --from-literal=mongodb-uri='mongodb+srv://user:password@cluster.mongodb.net/systemcraft' \
+  --from-literal=openrouter-api-key='sk-or-v1-your-key' \
+  --from-literal=firebase-service-account-key='{"type":"service_account",...}' \
+  --dry-run=client -o yaml > /tmp/raw-secret.yaml
+```
+
+**Step 2 — Encrypt it with `kubeseal`:**
+```bash
+kubeseal \
+  --controller-name sealed-secrets \
+  --controller-namespace kube-system \
+  --format yaml \
+  < /tmp/raw-secret.yaml \
+  > kubernetes/sealed-secrets/systemcraft-sealed-secret.yaml
+```
+
+**Step 3 — Clean up and commit:**
+```bash
+# Delete the plaintext — never commit this
+rm /tmp/raw-secret.yaml
+
+# Commit the encrypted version — safe for Git
+git add kubernetes/sealed-secrets/systemcraft-sealed-secret.yaml
+git commit -m "feat(secrets): add sealed secret for systemcraft"
+```
+
+### How It Works
+
+```
+┌─────────────┐     kubeseal      ┌──────────────────┐
+│ Raw Secret  │ ──────────────▶  │  SealedSecret    │
+│ (plaintext) │   encrypts with   │  (encrypted YAML)│
+│ NEVER in Git│   cluster cert    │  ✅ Safe for Git  │
+└─────────────┘                   └────────┬─────────┘
+                                           │
+                                    git push / ArgoCD sync
+                                           │
+                                           ▼
+                               ┌───────────────────────┐
+                               │ Sealed Secrets        │
+                               │ Controller (in-cluster)│
+                               │ Decrypts → K8s Secret │
+                               └───────────────────────┘
+```
+
+### Rotating Secrets
+
+To rotate a secret (e.g., new MongoDB password):
+
+```bash
+# 1. Create a new raw secret with updated values
+kubectl create secret generic systemcraft-secrets \
+  --namespace default \
+  --from-literal=mongodb-uri='mongodb+srv://user:NEW_PASSWORD@...' \
+  --from-literal=openrouter-api-key='sk-or-v1-...' \
+  --from-literal=firebase-service-account-key='...' \
+  --dry-run=client -o yaml > /tmp/raw-secret.yaml
+
+# 2. Re-encrypt
+kubeseal --controller-name sealed-secrets \
+  --controller-namespace kube-system \
+  --format yaml \
+  < /tmp/raw-secret.yaml \
+  > kubernetes/sealed-secrets/systemcraft-sealed-secret.yaml
+
+# 3. Clean up, commit, and push
+rm /tmp/raw-secret.yaml
+git add kubernetes/sealed-secrets/systemcraft-sealed-secret.yaml
+git commit -m "chore(secrets): rotate mongodb credentials"
+git push
+
+# 4. ArgoCD auto-syncs → controller decrypts → pods restart with new secret
+```
+
+### Helm Chart Integration
+
+The Helm chart includes a conditional `SealedSecret` template. Enable it per-environment:
+
+```bash
+# Dev — uses plain secrets (create manually)
+helm install systemcraft-dev ./helm/systemcraft \
+  -f helm/systemcraft/values-dev.yaml
+
+# Prod — uses sealed secrets (auto-decrypted)
+helm install systemcraft-prod ./helm/systemcraft \
+  -f helm/systemcraft/values-prod.yaml
+```
+
+In dev, create the secret manually:
+```bash
+kubectl create secret generic systemcraft-secrets \
+  --from-literal=mongodb-uri='your-dev-connection-string' \
+  --from-literal=openrouter-api-key='your-dev-key' \
+  --from-literal=firebase-service-account-key='your-dev-sa-key'
+```
+
+### Backup: Export the Sealing Key
+
+The sealed-secrets controller generates a sealing key pair. **If the cluster is destroyed, you need this key to decrypt existing sealed secrets.** Back it up:
+
+```bash
+kubectl get secret -n kube-system -l sealedsecrets.bitnami.com/sealed-secrets-key -o yaml > sealing-key-backup.yaml
+```
+
+Store this backup securely (e.g., in a password manager or cloud KMS) — **never in Git**.
+
+---
+
+*This completes the full cycle: Dev -> Containerize -> Proxy -> Orchestrate -> Autoscale -> Monitor -> Alert -> Encrypt.*
+

--- a/helm/systemcraft/templates/deployment.yaml
+++ b/helm/systemcraft/templates/deployment.yaml
@@ -50,5 +50,15 @@ spec:
         - name: MONGODB_URL
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.secrets.mongodb.secretName }}
-              key: {{ .Values.secrets.mongodb.key }}
+              name: {{ .Values.secrets.secretName }}
+              key: mongodb-uri
+        - name: OPENROUTER_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets.secretName }}
+              key: openrouter-api-key
+        - name: FIREBASE_SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.secrets.secretName }}
+              key: firebase-service-account-key

--- a/helm/systemcraft/templates/sealed-secret.yaml
+++ b/helm/systemcraft/templates/sealed-secret.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.sealedSecrets.enabled }}
+# ──────────────────────────────────────────────────────────────
+# Bitnami Sealed Secret — decrypted by the controller into a
+# regular K8s Secret named "{{ .Values.secrets.secretName }}"
+# ──────────────────────────────────────────────────────────────
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: {{ .Values.secrets.secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "systemcraft.labels" . | nindent 4 }}
+    managed-by: sealed-secrets
+spec:
+  encryptedData:
+    {{- range $key, $value := .Values.sealedSecrets.encryptedData }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  template:
+    metadata:
+      name: {{ .Values.secrets.secretName }}
+      namespace: {{ .Release.Namespace }}
+      labels:
+        {{- include "systemcraft.labels" . | nindent 8 }}
+    type: Opaque
+{{- end }}

--- a/helm/systemcraft/values-dev.yaml
+++ b/helm/systemcraft/values-dev.yaml
@@ -28,3 +28,6 @@ hpa:
 
 serviceMonitor:
   enabled: false
+
+sealedSecrets:
+  enabled: false

--- a/helm/systemcraft/values-prod.yaml
+++ b/helm/systemcraft/values-prod.yaml
@@ -34,3 +34,17 @@ hpa:
       averageUtilization: 40
     memory:
       averageUtilization: 80
+
+# ── Sealed Secrets (Bitnami) ────────────────────────────────
+# Generate real values with:
+#   kubectl create secret generic systemcraft-secrets \
+#     --from-literal=mongodb-uri='...' \
+#     --from-literal=openrouter-api-key='...' \
+#     --from-literal=firebase-service-account-key='...' \
+#     --dry-run=client -o yaml | kubeseal --format yaml
+sealedSecrets:
+  enabled: true
+  encryptedData:
+    mongodb-uri: "<kubeseal encrypted value>"
+    openrouter-api-key: "<kubeseal encrypted value>"
+    firebase-service-account-key: "<kubeseal encrypted value>"

--- a/helm/systemcraft/values.yaml
+++ b/helm/systemcraft/values.yaml
@@ -69,10 +69,20 @@ env:
   NODE_ENV: production
 
 # ── Secrets ──────────────────────────────────────────────────
+# Name of the K8s Secret the deployment mounts.
+# In prod this Secret is auto-created by the Sealed Secrets controller;
+# in dev you create it manually with kubectl.
 secrets:
-  mongodb:
-    secretName: mongodb-secret
-    key: uri
+  secretName: systemcraft-secrets
+
+# ── Sealed Secrets (Bitnami) ────────────────────────────────
+# When enabled, a SealedSecret resource is rendered by the Helm
+# chart.  The sealed-secrets controller decrypts it into a
+# regular Secret named {{ .Values.secrets.secretName }}.
+sealedSecrets:
+  enabled: false
+  # Override in values-prod.yaml with kubeseal-encrypted values
+  encryptedData: {}
 
 # ── Horizontal Pod Autoscaler ────────────────────────────────
 hpa:

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -56,5 +56,15 @@ spec:
         - name: MONGODB_URL
           valueFrom:
             secretKeyRef:
-              name: mongodb-secret
-              key: uri
+              name: systemcraft-secrets
+              key: mongodb-uri
+        - name: OPENROUTER_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: systemcraft-secrets
+              key: openrouter-api-key
+        - name: FIREBASE_SERVICE_ACCOUNT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: systemcraft-secrets
+              key: firebase-service-account-key

--- a/kubernetes/sealed-secrets/systemcraft-sealed-secret.yaml
+++ b/kubernetes/sealed-secrets/systemcraft-sealed-secret.yaml
@@ -1,0 +1,45 @@
+# ──────────────────────────────────────────────────────────────
+# Bitnami Sealed Secret for SystemCraft
+#
+# This file contains ENCRYPTED secret data that only the
+# sealed-secrets controller in your cluster can decrypt.
+#
+# ⚠️  DO NOT edit the encryptedData values by hand.
+# Use the kubeseal CLI to regenerate this file:
+#
+#   kubectl create secret generic systemcraft-secrets \
+#     --namespace default \
+#     --from-literal=mongodb-uri='mongodb+srv://...' \
+#     --from-literal=openrouter-api-key='sk-or-v1-...' \
+#     --from-literal=firebase-service-account-key='{"type":"service_account",...}' \
+#     --dry-run=client -o yaml \
+#     | kubeseal \
+#         --controller-name sealed-secrets \
+#         --controller-namespace kube-system \
+#         --format yaml \
+#     > kubernetes/sealed-secrets/systemcraft-sealed-secret.yaml
+#
+# Then commit the output — it's safe to store in Git.
+# ──────────────────────────────────────────────────────────────
+
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: systemcraft-secrets
+  namespace: default
+  labels:
+    app: system-craft
+    managed-by: sealed-secrets
+spec:
+  encryptedData:
+    # ── Replace these placeholders with actual kubeseal output ──
+    mongodb-uri: AgBy3i4OJSWK+PiTySYZZA9rO43cGDnNBJPlT0bgSample...
+    openrouter-api-key: AgCx7k2RQTWL+QjUzTAaAB0sP54dHEoOCKQmU1chSample...
+    firebase-service-account-key: AgDz9m3SRUXI+RkVzUBbBC1tQ65eIFpPDLRnV2diSample...
+  template:
+    metadata:
+      name: systemcraft-secrets
+      namespace: default
+      labels:
+        app: system-craft
+    type: Opaque


### PR DESCRIPTION
- Add SealedSecret manifest for encrypted secrets in Git (mongodb, openrouter, firebase SA)
- Add conditional Helm template for SealedSecret (enabled in prod, disabled in dev)
- Consolidate secrets from mongodb-secret to systemcraft-secrets with 3 keys
- Update raw K8s and Helm deployment to reference MONGODB_URL, OPENROUTER_API_KEY, FIREBASE_SERVICE_ACCOUNT_KEY
- Document seal/unseal workflow, rotation, backup, and Helm integration in KUBERNETES.md