### PR TITLE
feat(network): implement zero-trust kubernetes network policies

### DIFF
--- a/helm/systemcraft/templates/network-policy.yaml
+++ b/helm/systemcraft/templates/network-policy.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "systemcraft.fullname" . }}
+  labels:
+    {{- include "systemcraft.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "systemcraft.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow traffic from the ingress controller to the app port
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.ingress.namespaceSelector.matchLabels | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.targetPort }}
+  egress:
+    {{- if .Values.networkPolicy.egress.allowExternal }}
+    # Allow DNS resolution
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow HTTPS for external APIs (Firebase, OpenRouter, etc.)
+    - ports:
+        - protocol: TCP
+          port: 443
+    # Allow MongoDB default port
+    - ports:
+        - protocol: TCP
+          port: 27017
+    {{- end }}
+{{- end }}

--- a/helm/systemcraft/values.yaml
+++ b/helm/systemcraft/values.yaml
@@ -110,3 +110,15 @@ serviceMonitor:
   interval: 15s
   path: /api/metrics
   releaseLabel: prometheus
+
+# ── Network Policy ───────────────────────────────────────────
+networkPolicy:
+  enabled: true
+  ingress:
+    # Labels for the namespace where the ingress controller runs
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: ingress-nginx
+  egress:
+    # By default allow HTTPS and DNS, plus MongoDB (27017)
+    allowExternal: true

--- a/kubernetes/network-policy.yaml
+++ b/kubernetes/network-policy.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: systemcraft-network-policy
+  labels:
+    app.kubernetes.io/name: systemcraft
+    app.kubernetes.io/instance: systemcraft
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: systemcraft
+      app.kubernetes.io/instance: systemcraft
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow traffic from the ingress controller to the app port
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    # Allow DNS resolution
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow HTTPS for external APIs (Firebase, OpenRouter, etc.)
+    - ports:
+        - protocol: TCP
+          port: 443
+    # Allow MongoDB default port
+    - ports:
+        - protocol: TCP
+          port: 27017


### PR DESCRIPTION
- Add NetworkPolicy to restrict ingress to the Nginx Ingress Controller
- Restrict egress traffic to DNS (UDP/TCP 53), HTTPS (443), and MongoDB (27017)
- Provide configurable Helm parameters to toggle the policies
- Include raw NetworkPolicy manifest for non-Helm deployments