### PR TITLE
fix: Removed the unused lint

### DIFF
--- a/components/canvas/DesignCanvas.tsx
+++ b/components/canvas/DesignCanvas.tsx
@@ -242,7 +242,6 @@ export function DesignCanvas({
     if (initialWhiteboardData && !whiteboardDataRef.current) {
         setWhiteboardData(initialWhiteboardData);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialNodes, initialConnections, initialWhiteboardData]);
 
   // Keep stateRef in sync so parent can read current canvas state at any time

--- a/components/canvas/WhiteboardClient.tsx
+++ b/components/canvas/WhiteboardClient.tsx
@@ -271,16 +271,15 @@ export default function WhiteboardClient({ initialData, onSave, readOnly = false
     }, [drawElement]);
 
     // ─── Animation loop ────────────────────────────────────────
-    const animFrameRef = useRef<number>(0);
-    const renderLoop = useCallback(() => {
-        render();
-        animFrameRef.current = requestAnimationFrame(renderLoop);
-    }, [render]);
-
     useEffect(() => {
-        animFrameRef.current = requestAnimationFrame(renderLoop);
-        return () => cancelAnimationFrame(animFrameRef.current);
-    }, [renderLoop]);
+        let frameId: number;
+        const loop = () => {
+            render();
+            frameId = requestAnimationFrame(loop);
+        };
+        frameId = requestAnimationFrame(loop);
+        return () => cancelAnimationFrame(frameId);
+    }, [render]);
 
     // ─── History helpers ───────────────────────────────────────
     const pushHistory = useCallback((prev: WhiteboardElement[]) => {

--- a/tests/load/k6-spike.js
+++ b/tests/load/k6-spike.js
@@ -19,7 +19,7 @@ export const options = {
     },
 };
 
-export default function () {
+export default function spikeTest() {
     const res = http.get(`${BASE_URL}/api/health`);
     check(res, { 'status 200': (r) => r.status === 200 });
     // No Sleep to maximize load


### PR DESCRIPTION
- renderLoop issue by redefining the animation loop inside the useEffect
- Named the anonymous default export spikeTest